### PR TITLE
Patch Dynamixel static error issue

### DIFF
--- a/software/reachy/parts/motor.py
+++ b/software/reachy/parts/motor.py
@@ -158,7 +158,9 @@ class DynamixelMotor(object):
         Args:
             activate (bool): whether to activate/deactivate the static error issue fix
         
-        If activated, the static error fix will check the reach position a fixed delay after the send of a new goal position. The static error may result in the motor forcing, and yet not managing to move. To prevent this behavior we automatically adjust the target goal position to reduce this error.
+        If activated, the static error fix will check the reach position a fixed delay after the send of a new goal position. 
+        The static error may result in the motor's load increasing, and yet not managing to move. 
+        To prevent this behavior we automatically adjust the target goal position to reduce this error.
         """
         self._use_static_fix = activate
 

--- a/software/reachy/parts/motor.py
+++ b/software/reachy/parts/motor.py
@@ -159,7 +159,7 @@ class DynamixelMotor(object):
             activate (bool): whether to activate/deactivate the static error issue fix
 
         If activated, the static error fix will check the reach position a fixed delay after the send of a new goal position.
-        The static error may result in the motor's load increasing, and yet not managing to move. 
+        The static error may result in the motor's load increasing, and yet not managing to move.
         To prevent this behavior we automatically adjust the target goal position to reduce this error.
         """
         self._use_static_fix = activate

--- a/software/reachy/parts/motor.py
+++ b/software/reachy/parts/motor.py
@@ -157,8 +157,8 @@ class DynamixelMotor(object):
 
         Args:
             activate (bool): whether to activate/deactivate the static error issue fix
-        
-        If activated, the static error fix will check the reach position a fixed delay after the send of a new goal position. 
+
+        If activated, the static error fix will check the reach position a fixed delay after the send of a new goal position.
         The static error may result in the motor's load increasing, and yet not managing to move. 
         To prevent this behavior we automatically adjust the target goal position to reduce this error.
         """

--- a/software/reachy/parts/motor.py
+++ b/software/reachy/parts/motor.py
@@ -6,13 +6,18 @@ Define:
 """
 
 import time
+import logging
 import numpy as np
 
+from threading import Timer
 from collections import deque
 from pyquaternion import Quaternion
 from orbita import Actuator as OrbitaModel
 
 from ..trajectory.interpolation import interpolation_modes
+
+
+logger = logging.getLogger(__name__)
 
 
 class DynamixelMotor(object):
@@ -36,6 +41,8 @@ class DynamixelMotor(object):
 
         self._offset = config['offset']
         self._direct = config['orientation'] == 'direct'
+
+        self._timer = None
 
     def __repr__(self):
         """Motor representation."""
@@ -62,6 +69,7 @@ class DynamixelMotor(object):
     def goal_position(self, value):
         if not self.compliant:
             self._motor.target_rot_position = self._to_motor_pos(value)
+            self._schedule_static_error_fix(delay=1)
 
     @property
     def offset(self):
@@ -140,6 +148,28 @@ class DynamixelMotor(object):
             traj_player.wait()
 
         return traj_player
+
+    # Patch dynamixel controller issue when the motor forces
+    # while not managing to reachy the goal position
+    def _schedule_static_error_fix(self, delay):
+        if self._timer is not None:
+            self._timer.cancel()
+        self._timer = Timer(delay, self._fix_static_error)
+        self._timer.start()
+
+    def _fix_static_error(self, threshold=2):
+        error = (self.present_position - self.goal_position)
+
+        if abs(error) > threshold:
+            pos = self.goal_position + error / 2
+            logger.info(f'Fix static error controller', extra={
+                'goal_position': self.goal_position,
+                'present_position': self.present_position,
+                'fixed_goal_position': pos,
+            })
+
+            self._motor.target_rot_position = self._to_motor_pos(pos)
+            self._timer = None
 
 
 class OrbitaActuator(object):


### PR DESCRIPTION
The PID controller inside the dynamixel motors may sometimes results in overload. 
This may occur especially in the following case: You set a new goal position close to where the motor is currently. There is not enough force to actually start the motor, so it doesn't move and yet it keeps applying some load.

Unfortunately, trying to fix the problem by changing the P and/or I gain in the controller results in poor behaviour. 

We propose here a semi-automatic behaviour where when you send a command, after a fixed delay (eg. 1s), we check the reach position and adjust the goal position in consequence and thus reduce the load.

This approach may result in some unwanted behaviour and is thus not activated by default.